### PR TITLE
Fixed tagname uppercase bug

### DIFF
--- a/jquery.popover.coffee
+++ b/jquery.popover.coffee
@@ -112,7 +112,7 @@
 
       # popover click
       popover.bind "click", (e) ->
-        if(e.target.tagName != 'a')
+        if(e.target.tagName != 'A')
           popover.addClass('sticky')
           e.stopPropagation()
           e.preventDefault()


### PR DESCRIPTION
Element.tagName is always uppercase, see http://stackoverflow.com/a/27223824/1781752.
